### PR TITLE
Add separate file mode options for directories and sub files.

### DIFF
--- a/chmodr.js
+++ b/chmodr.js
@@ -5,6 +5,12 @@ var fs = require("fs")
 , path = require("path")
 
 function chmodr (p, mode, submode, cb) {
+	if(typeof submode == 'function'){
+		cb = submode;
+		submode = mode;
+	}
+	submode = submode || mode;
+
   fs.readdir(p, function (er, children) {
     // any error other than ENOTDIR means it's not readable, or
     // doesn't exist.  give up.
@@ -29,6 +35,7 @@ function chmodr (p, mode, submode, cb) {
 }
 
 function chmodrSync (p, mode, submode) {
+	submode = submode || mode;
   var children
   try {
     children = fs.readdirSync(p)


### PR DESCRIPTION
There are times people want to set different file modes for directories and files.
For example,I use chmodr with my nginx static files,I want set directories with mode 0755(will add files to it),but want files to be 0444(which is readonly).
