### PR TITLE
Use fs.lstat for checking if file is a directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 before_script: npm install -g npm@latest
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
   - 'iojs'

--- a/chmodr.js
+++ b/chmodr.js
@@ -5,54 +5,43 @@ var fs = require("fs")
 , path = require("path")
 
 function chmodr (p, mode, cb) {
-  fs.readdir(p, function (er, children) {
-    // any error other than ENOTDIR means it's not readable, or
-    // doesn't exist.  give up.
-    if (er && er.code !== "ENOTDIR")
-      return cb(er)
-    var isDir = !er
-    var m = isDir ? dirMode(mode) : mode
-    if (er || !children.length)
-      return fs.chmod(p, m, cb)
-
-    var len = children.length
-    var errState = null
-    children.forEach(function (child) {
-      var pathChild = path.resolve(p, child);
-      fs.lstat(pathChild, function(er, stats) {
-        if (er)
-          return cb(er)
-        if (!stats.isSymbolicLink())
-          chmodr(pathChild, mode, then)
-        else
-          then()
+  fs.lstat(p, function (er, stats) {
+    if (er) return cb(er)
+    if (stats.isSymbolicLink()) return cb()
+    if (stats.isDirectory()) {
+      fs.readdir(p, function (er, children) {
+        if (er) return cb(er)
+        if (!children.length) return fs.chmod(p, dirMode(mode), cb)
+        var len = children.length
+        var errState = null
+        children.forEach(function (child) {
+          chmodr(path.resolve(p, child), mode, then)
+        })
+        function then (er) {
+          if (errState) return
+          if (er) return cb(errState = er)
+          if (-- len === 0) return fs.chmod(p, dirMode(mode), cb)
+        }
       })
-    })
-    function then (er) {
-      if (errState) return
-      if (er) return cb(errState = er)
-      if (-- len === 0) return fs.chmod(p, dirMode(mode), cb)
+    } else {
+      return fs.chmod(p, mode, cb)
     }
   })
 }
 
 function chmodrSync (p, mode) {
   var children
-  try {
-    children = fs.readdirSync(p)
-  } catch (er) {
-    if (er && er.code === "ENOTDIR") return fs.chmodSync(p, mode)
-    throw er
+  var stats = fs.lstatSync(p)
+  if (stats.isSymbolicLink())
+    return;
+  if (stats.isDirectory()) {
+    fs.readdirSync(p).forEach(function (child) {
+      chmodrSync(path.resolve(p, child), mode)
+    })
+    return fs.chmodSync(p, dirMode(mode))
+  } else {
+    return fs.chmodSync(p, mode)
   }
-  if (!children.length) return fs.chmodSync(p, dirMode(mode))
-
-  children.forEach(function (child) {
-    var pathChild = path.resolve(p, child)
-    var stats = fs.lstatSync(pathChild)
-    if (!stats.isSymbolicLink())
-      chmodrSync(pathChild, mode)
-  })
-  return fs.chmodSync(p, dirMode(mode))
 }
 
 // If a party has r, add x


### PR DESCRIPTION
Instead of relying on ENOTDIR exceptions.

This fixes weird behavior of Windows when using NFS. In such environment
fs.readdir returns ENOENT instead of ENOTDIR for normal files. This
causes chmodr to fail on the first file. This commit changes
implementation to straightforward checking if path is directory, so it
works on all platforms and filesystems.

Because there are usually more files than directories to chmod,
this is also more performant solution, as it avoids triple system call
for files (fs.readdir, fs.lstat, fs.chmod  becomes  fs.lstat, fs.chmod),
and uses truple  and instead uses triple system call for directories
(fs.readdir, fs.chmod  becomes  fs.lstat, fs.readdir, fs.chmod).

---

This commit is a result of debugging failing [bower](https://github.com/bower/bower) tests on Windows. After this change the the test changing read-only permissions and removing `.git` directory is passing in VM environment (Parallels Desktop 11 on OSX). I hope you'll find time to review it and release it, so I can update bower as well.